### PR TITLE
Allow sync workflow to trigger another workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -5,6 +5,8 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions: {}
+
 jobs:
   create_token:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -5,16 +5,25 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
-permissions:
-  pull-requests: write
-  contents: write
-
 jobs:
+  create_token:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      token: ${{ steps.create.outputs.token }}
+    steps:
+      - uses: tibdex/github-app-token@v2
+        id: create
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
   sync:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: create_token
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ needs.create_token.outputs.token }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## 問題
syncワークフローが作成したPRでtextlintのワークフローが発動しない。

## 原因
syncワークフローでデフォルトの `GITHUB_TOKEN` が使用されているが、このトークンを用いた操作で発生したイベントでは別のワークフローが発動されないという制約がある(cf. https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow) 。

## 対処
GitHub Apps経由で発行したアクセストークンを用いるように変更(cf. https://zenn.dev/suzutan/articles/how-to-use-github-apps-token-in-github-actions) 。