### PR TITLE
Fix sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -8,25 +8,16 @@ on:
 permissions: {}
 
 jobs:
-  create_token:
+  sync:
     runs-on: ubuntu-latest
-    timeout-minutes: 3
-    outputs:
-      token: ${{ steps.create.outputs.token }}
+    timeout-minutes: 10
     steps:
       - uses: tibdex/github-app-token@v2
-        id: create
+        id: create_token
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.PRIVATE_KEY }}
 
-  sync:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: create_token
-    env:
-      GITHUB_TOKEN: ${{ needs.create_token.outputs.token }}
-    steps:
       - uses: actions/checkout@v4
         with:
           ref: main
@@ -72,13 +63,19 @@ jobs:
             echo "diff_main=0" >> $GITHUB_OUTPUT
             echo "main is in sync with upstream"
           fi
+        env:
+          GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
 
       - name: Check if sync pull request exists
         id: sync_pr_existence
         run: |
           echo "count=$(gh pr list --head sync --base main | wc -l)" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
 
       - name: Create pull request if needed
         if: ${{steps.sync_pr_existence.outputs.count == 0 && steps.sync.outputs.diff_main == 1}}
         run: |
           gh pr create --head "sync" --base "main" --title "Sync with upstream" --body ""
+        env:
+          GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}


### PR DESCRIPTION
secret扱いの値はjobの出力にできない(スキップされる)ようなので、sync job内でトークンを生成するように変更しました。

cf. https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs

> Outputs containing secrets are redacted on the runner and not sent to GitHub Actions.