### PR TITLE
Fix sync workflow (finally)

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Sync with upstream
         id: sync
@@ -55,16 +56,19 @@ jobs:
 
           if ! git diff --quiet main; then
             echo "diff_main=1" >> $GITHUB_OUTPUT
-
-            echo ::group::Pushing sync branch
-            git push -f origin sync
-            echo ::endgroup::
           else
             echo "diff_main=0" >> $GITHUB_OUTPUT
             echo "main is in sync with upstream"
           fi
         env:
           GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
+
+      - name: Push to sync branch
+        if: ${{ steps.sync.outputs.diff_main == 1 }}
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ steps.create_token.outputs.token }}
+          branch: sync
 
       - name: Check if sync pull request exists
         id: sync_pr_existence
@@ -74,7 +78,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
 
       - name: Create pull request if needed
-        if: ${{steps.sync_pr_existence.outputs.count == 0 && steps.sync.outputs.diff_main == 1}}
+        if: ${{ steps.sync_pr_existence.outputs.count == 0 && steps.sync.outputs.diff_main == 1 }}
         run: |
           gh pr create --head "sync" --base "main" --title "Sync with upstream" --body ""
         env:


### PR DESCRIPTION
syncブランチへのpush時に[ad-m/github-push-action](https://github.com/ad-m/github-push-action)を使ってGitHub Appsのトークンを設定することで上手くいきました。

checkoutにおける`persist-credentials: false` については[こちら](https://github.com/ad-m/github-push-action/issues/173#issuecomment-1680552281)を参照。

成功例: #39 