### PR TITLE
Use `husky` instead of `husky install`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "lint": "textlint .",
     "lint-staged": "lint-staged",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "devDependencies": {
     "husky": "^9.0.7",


### PR DESCRIPTION
husky v9.0.1から `prepare` の方法が `husky install` から `husky` に変わったため変更します。

ref: https://github.com/typicode/husky/releases/tag/v9.0.1